### PR TITLE
LUGG-221 : Adding more targeted selectors for sidebar blocks

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -820,6 +820,7 @@ aside .item-list > ul {
     /*display: block !important;*/
     margin: 0;
     padding: 0;
+    list-style: none;
 }
 
 aside li.leaf > a,
@@ -837,10 +838,10 @@ aside .item-list > ul > li > a:active {
     background-color: rgba(52, 52, 52, 0.1);
 }
 
-aside li.leaf > a.facetapi-inactive:after,
-aside li.expanded > a.facetapi-inactive:after,
-aside li.collapsed > a.facetapi-inactive:after,
-aside .item-list > ul > li > a.facetapi-inactive:after {
+aside li.leaf > a:not(.facetapi-active):after,
+aside li.expanded > a:after,
+aside li.collapsed > a:after,
+aside .item-list > ul > li > a:not(.facetapi-active):after {
     display: inline-block;
     width: 0;
     height: 0;
@@ -854,6 +855,10 @@ aside .item-list > ul > li > a.facetapi-inactive:after {
     filter: alpha(opacity=30);
     position: absolute;
     right: 12px;
+}
+
+aside li.leaf > a:after {
+
 }
 
 aside .facetapi-active {

--- a/css/suitcase_normal.css
+++ b/css/suitcase_normal.css
@@ -64,10 +64,10 @@
         background-color: rgba(52, 52, 52, 0.1);
     }
 
-    aside li.leaf > a.facetapi-inactive:after,
-    aside li.expanded > a.facetapi-inactive:after,
-    aside li.collapsed > a.facetapi-inactive:after,
-    aside .item-list > ul > li > a.facetapi-inactive:after {
+    aside li.leaf > a:not(.facetapi-active):after,
+    aside li.expanded > a:after,
+    aside li.collapsed > a:after,
+    aside .item-list > ul > li > a:not(.facetapi-active):after {
         border-left-width: 4px;
         border-top-width: 6px;
         border-bottom-width: 6px;


### PR DESCRIPTION
## Summary

Unordered list dots were appearing in the sidebar blocks for the book module's block. Arrows were disappearing on none-factetapi blocks.
## Changes
- Added list-style: none to all unordered lists within the sidebar
- Changed current sidebar styling to correctly target all blocks
## To Test

1) Pull most recent suitcase commits in a site that uses Suitcase
2) Clear cache
3) Check for no unordered list bullet circles/triangles
4) Check for no triangle on active solr search filter terms
