### PR TITLE
Flexslider caption, paging and control-nav styling

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -1082,6 +1082,25 @@ aside .block .view-content > .views-row.views-row-even {
     height: inherit;
 }
 
+.flex-control-paging li a {
+  background: none repeat scroll 0 0 rgba(231, 231, 231, 0.6);
+}
+
+.flex-control-paging li a.flex-active {
+  background: none repeat scroll 0 0 rgba(206, 17, 38, 0.9);
+  
+}
+
+.flex-control-paging li {
+	padding:.5em 0 0 0;
+
+}
+
+.flex-control-nav {
+	background: rgba(234, 226, 183, 0.95);
+	z-index: 2;
+	bottom: 0;
+}
 
 
 /*////////////////////////////////////*/


### PR DESCRIPTION
The caption does need to be moved up to leave room for the nav. However, it isn't too high, so that if one did not want the nav, it still looks alright to the eye.

Photo with nav
![image](https://cloud.githubusercontent.com/assets/4522574/4827044/dbb524d0-5f75-11e4-822d-9c692acd4757.png)

Photo without nav
![image](https://cloud.githubusercontent.com/assets/4522574/4827071/0b8ce440-5f76-11e4-9a02-425b5b132c61.png)
