### PR TITLE
LUGG-346 : Adding text color to a,p,li,span,strong,em tags

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -211,6 +211,10 @@ sup {
     vertical-align: super;
 }
 
+a, p, li, span, strong, em {
+    color: #333;
+}
+
 @media print {
     a {
         color: blue;


### PR DESCRIPTION
Omega thinks it is a good idea to put text in a <li> tags which do not have `color: #333` applied to them. This results in darker text than the rest of the page.