### PR TITLE
LUGG-432 : Bringing ul bullets back to browser defaults

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -211,6 +211,18 @@ sup {
     vertical-align: super;
 }
 
+ul {
+    list-style-type: disc;
+}
+
+ul ul, ol ul {
+    list-style-type: circle;
+}
+
+ol ol ul, ol ul ul, ul ol ul, ul ul ul {
+    list-style-type: square;
+}
+
 @media print {
     a {
         color: blue;


### PR DESCRIPTION
Omega contains undesirable overwrites to ul/ol bullet styling.