### PR TITLE
LUGG-555 : Increasing spacing of ol and ul so all digits are shown

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -240,7 +240,7 @@ img {
 
 .node ol,
 .node ul {
-  padding-left: 1.7em;
+  padding-left: 3.5em;
 }
 
 .node {


### PR DESCRIPTION
This PR increases the left-hand indent of order/un-ordered lists so that the numbers or bullets are fully displayed.

To test, checkout this branch, clear cache if you are caching, create an ordered list with at least 10 items, assert that the number "10" is fully displayed next to the tenth item.