### PR TITLE
LUGG-699 - Footer Styling

### DIFF
--- a/suitcase_interim/css/suitcase.css
+++ b/suitcase_interim/css/suitcase.css
@@ -2398,3 +2398,10 @@ figure .insert-default-image-styling + figcaption {
 .view-id-my_resources .view-content {
     overflow-x: auto;
 }
+
+/*------ Font Antialiasing Fixes------*/
+body {
+    -moz-osx-font-smoothing: grayscale;
+    -webkit-font-smoothing: antialiased;
+    -o-font-smoothing: antialiased;
+}


### PR DESCRIPTION
Fixed anti-aliasing issue in footer that was making it difficult to discern bolded text from non-bolded text. I tested these changes on Safari, Chrome, Firefox, and Opera.
For a more detailed explanation of how this works, view:
https://web.archive.org/web/20131019233655/http://tanookilabs.com/your-fonts-look-bad-in-chrome-heres-the-fix
http://stackoverflow.com/questions/14477265/css-white-text-on-black-background-looks-bolder
http://stackoverflow.com/questions/11459746/webfont-smoothing-and-antialiasing-in-firefox-and-opera?lq=1

Expected behavior when testing my changes:
[Should look like this](http://imgur.com/pUYyMvZ)
[But not this](http://imgur.com/JCtjl9j)