### PR TITLE
LUGG-699 - Footer Styling

### DIFF
--- a/suitcase_interim/css/suitcase.css
+++ b/suitcase_interim/css/suitcase.css
@@ -2399,3 +2399,10 @@ figure .insert-default-image-styling + figcaption {
 .view-id-my_resources .view-content {
     overflow-x: auto;
 }
+
+/*---Fixing antialiasing for footers---*/
+footer {
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    -o-font-smoothing: antialiased;
+}


### PR DESCRIPTION
Made antialiasing changes footer-targeted. Attempting to reduce footer font fuzziness while leaving the wordmark/department name unaffected.

Tested in IE 11, Opera, Safari, Chrome and Firefox.
[Should look like this](http://imgur.com/pUYyMvZ)
[and not like this](http://imgur.com/JCtjl9j)