### PR TITLE
LUGG-519 Responsive images in content

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -230,9 +230,9 @@ tr:hover td {
     background-color: transparent;
 }
 
-img {
+.field-type-text-long img, .field-type-text-with-summary img {
     max-width: 100%;
-    height: auto;
+    height: auto !important;
 }
 
 @media print {


### PR DESCRIPTION
Changed responsive image CSS in img tag to target only body content so it doesn't mess up images elsewhere.