### PR TITLE
LUGG-881 Adding suitcase_config_logo_url and suitcase_config_logo_alt

### DIFF
--- a/template.php
+++ b/template.php
@@ -36,9 +36,16 @@ function suitcase_preprocess_region(&$vars) {
     $vars['suitcase_config_logo'] = FALSE;
     $logo = variable_get('suitcase_config_logo');
     $vars['site_name'] = variable_get('site_name');
+
+    // TODO: Add this as a field in suitcase_config. Otherwise the only way to
+    // set this is 'drush vset suitcase_config_logo_url "http://example.com"'
+    // and 'drush vset suitcase_config_logo_alt "Go to example.com"'.
+    $url = variable_get('suitcase_config_logo_url', $GLOBALS['base_url']);;
+    $logo_alt = variable_get('suitcase_config_logo_alt', 'Go to ' . $vars['site_name'] . ' home');
+
     if ($logo) {
       $logo_url = file_create_url($logo['uri']);
-      $vars['suitcase_config_logo'] = '<div class="logo-img"><a href="' . $GLOBALS['base_url'] . '" rel="home" title="' . $vars['site_name'] . '" class="active"><img src="' . $logo_url . '" alt="Go to ' . $vars['site_name'] . ' home" id="logo" /></a></div>';
+      $vars['suitcase_config_logo'] = '<div class="logo-img"><a href="' . $url . '" rel="home" class="active"><img src="' . $logo_url . '" alt="' . $logo_alt . '" title="' . $logo_alt . '" id="logo" /></a></div>';
     }
 
     $vars['dept_url'] = variable_get('dept_url', $default = NULL);


### PR DESCRIPTION
I added two variables since we also needed to change the alt attribute on the logo as well. Added the following variables.

suitcase_config_logo_url - eg https://extenson.iastate.edu
suitcase_config_logo_alt - eg Iowa State University Extension and Outreach

If we wanted to be thorough we could expose and set these variables in sutcase_config. I'm not sure that's quite necessary to put in the extra work as we're focusing more on suitcase_interim.
These variables can easily be set with drush:

drush vset suitcase_config_logo_url "https://extension.iastate.edu/"
drush vset suitcase_config_logo_alt "Iowa State University Extension and Outreach"