### PR TITLE
NCRAC-83 Fix word-break

### DIFF
--- a/css/suitcase.css
+++ b/css/suitcase.css
@@ -1931,7 +1931,6 @@ html.js input.form-autocomplete {
         /*display: block;*/
         word-wrap: break-word;
         -ms-word-break: break-all;
-        word-break: break-all;
         word-break: break-word;
     }
 


### PR DESCRIPTION
word-break: break-all was too heavy and was breaking incorrectly on
Firefox.